### PR TITLE
bugfix: insertion

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -14,7 +14,6 @@ pub fn kill_node(node: &NixNode) -> Result<NixNode, String> {
     let b = node.replace_with(a);
     let mut new_root = NixNode::new_root(b);
     loop {
-        dbg!("did one iteration of the inner loop");
         if let Some(parent) = new_root.parent() {
             new_root = parent;
         } else {
@@ -25,9 +24,10 @@ pub fn kill_node(node: &NixNode) -> Result<NixNode, String> {
 }
 
 /// what should be done is:
+/// Precondition: node is a attribute and parent is an attribute set
 /// (1) get parent attrset
-/// (2) iterate through children nodes, searching for one to delete
-/// (4) return with the replaced thing
+/// (2) iterate through children nodes, searching for node
+/// (4) return a modified tree with node deleted
 pub fn kill_node_attribute(node: &NixNode) -> Result<NixNode, String> {
     let parent = node.parent().unwrap();
     match parent.kind() {
@@ -52,8 +52,6 @@ pub fn kill_node_attribute(node: &NixNode) -> Result<NixNode, String> {
                 .last()
                 .unwrap_or(0);
             let new_parent = parent.green().remove_child(idx);
-            println!("the new parent is: {:?}", new_parent.to_string());
-            println!("the old parent is: {:?}", parent.to_string());
             let mut new_root = NixNode::new_root(parent.replace_with(new_parent));
             while let Some(parent) = new_root.parent() {
                 new_root = parent;
@@ -88,8 +86,9 @@ fn search_for_attr(
     exact_depth: Option<usize>,
 ) -> Result<Vec<(NixNode, String, usize)>, String> {
     // assuming that the root node is an attrset
+    // TODO if it's not, we should fail louder
     let mut stack = match AttrSet::cast((*root_node).clone()) {
-        Some(rn) => rn.entries().map(|x| (x, String::new())).collect(),
+        Some(rn) => rn.entries().map(|x| (x, String::new(), 0)).collect(),
         None => {
             println!("failed to convert!");
             Vec::new()
@@ -98,11 +97,10 @@ fn search_for_attr(
 
     let mut remaining_items_prev = stack.len();
     let mut remaining_items_cur = 0;
-    let mut cur_depth = 0;
     let mut result = Vec::new();
 
     while !stack.is_empty() {
-        let (cur_node, mut path) = stack.pop().unwrap();
+        let (cur_node, mut path, mut cur_depth) = stack.pop().unwrap();
         let cur_node_value = cur_node.value().unwrap();
         let cur_node_key = cur_node.key().unwrap();
 
@@ -113,7 +111,6 @@ fn search_for_attr(
         }
 
         if cur_depth > max_depth {
-            //return Err(format!("Attribute {} does not exist at depth {:?}", attr, max_depth));
             // failing softly here since we're past the max depth
             // might want to be a bit more loud
             return Ok(vec![]);
@@ -140,15 +137,11 @@ fn search_for_attr(
         } else {
             match cur_node_value.kind() {
                 NODE_ATTR_SET => {
-                    if is_match {
-                        result.push((cur_node_value, path, real_depth));
-                    } else {
-                        let cur_node_casted = AttrSet::cast(cur_node_value).unwrap();
-                        cur_node_casted.entries().for_each(|entry| {
-                            stack.insert(0, (entry, path.clone()));
-                            remaining_items_cur += 1;
-                        });
-                    }
+                    let cur_node_casted = AttrSet::cast(cur_node_value).unwrap();
+                    cur_node_casted.entries().for_each(|entry| {
+                        stack.push((entry, path.clone(), real_depth));
+                        remaining_items_cur += 1;
+                    });
                 }
                 NODE_STRING => {
                     // TODO this should morally speaking *actually* fail

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -93,8 +93,7 @@ fn search_for_attr(
 
     let mut result = Vec::new();
 
-    while !stack.is_empty() {
-        let (cur_node, mut path, cur_depth) = stack.pop().unwrap();
+    while let Some((cur_node, mut path, cur_depth)) = stack.pop() {
         let cur_node_value = cur_node.value().unwrap();
         let cur_node_key = cur_node.key().unwrap();
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -94,7 +94,7 @@ fn search_for_attr(
     let mut result = Vec::new();
 
     while !stack.is_empty() {
-        let (cur_node, mut path, mut cur_depth) = stack.pop().unwrap();
+        let (cur_node, mut path, cur_depth) = stack.pop().unwrap();
         let cur_node_value = cur_node.value().unwrap();
         let cur_node_key = cur_node.key().unwrap();
 
@@ -125,7 +125,6 @@ fn search_for_attr(
         } else {
             match cur_node_value.kind() {
                 NODE_ATTR_SET => {
-                    let orig_stack_size = stack.len();
                     let cur_node_casted = AttrSet::cast(cur_node_value).unwrap();
                     stack.extend(
                         cur_node_casted


### PR DESCRIPTION
The input insertion algorithm had a couple of bugs. This squishes them. The bugs:

- I was assuming that we could search the tree BFS style. However, the depth might increment by more than one due to the path consisting of multiple nodes. As a result, I added the depth to the stack. This is more of a correctness bug than something that was causing issues. Also fixes #10.
- `real_depth` should have been pushed onto the stack when the current node consisted of an attribute set, but `cur_depth` was being pushed. The result was an incorrectly computed depth and `get_inputs` not recognizing all inputs.